### PR TITLE
Add simple WordPress-like interface

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>MyCMS - Dashboard</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header class="top-bar">
+        <h1>MyCMS</h1>
+    </header>
+    <div class="container">
+        <nav class="side-menu">
+            <ul>
+                <li><a href="#">Dashboard</a></li>
+                <li><a href="#">Posts</a></li>
+                <li><a href="#">Media</a></li>
+                <li><a href="#">Pages</a></li>
+                <li><a href="#">Comments</a></li>
+                <li><a href="#">Appearance</a></li>
+                <li><a href="#">Plugins</a></li>
+                <li><a href="#">Users</a></li>
+                <li><a href="#">Settings</a></li>
+            </ul>
+        </nav>
+        <main class="content">
+            <h2>Welcome to your dashboard</h2>
+            <p>Use the menu to manage your site.</p>
+        </main>
+    </div>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,48 @@
+body {
+    margin: 0;
+    font-family: Arial, sans-serif;
+}
+
+.top-bar {
+    background-color: #23282d;
+    color: #fff;
+    padding: 10px 20px;
+}
+
+.top-bar h1 {
+    font-size: 20px;
+    margin: 0;
+}
+
+.container {
+    display: flex;
+    height: calc(100vh - 40px);
+}
+
+.side-menu {
+    width: 200px;
+    background: #1d2327;
+    color: #fff;
+}
+
+.side-menu ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.side-menu li a {
+    display: block;
+    color: #fff;
+    padding: 12px 16px;
+    text-decoration: none;
+}
+
+.side-menu li a:hover {
+    background: #2271b1;
+}
+
+.content {
+    flex: 1;
+    padding: 20px;
+}


### PR DESCRIPTION
## Summary
- add basic HTML layout with top bar and sidebar similar to WordPress dashboard
- include minimal CSS for layout and styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0198bd848327b2bb593a1e1e0986